### PR TITLE
Made WebApiHelper Options property public

### DIFF
--- a/src/WebApiHelper.cs
+++ b/src/WebApiHelper.cs
@@ -14,7 +14,7 @@ public class WebApiHelper<T>(string endpointRoute, WebApiHelperOptions? options 
     /// <summary>
     /// The passed options for the WebApiHelper.
     /// </summary>
-    private WebApiHelperOptions Options { get; } = options ?? new WebApiHelperOptions()
+    public WebApiHelperOptions Options { get; } = options ?? new WebApiHelperOptions()
     {
         JsonSerializerOptions = new(System.Text.Json.JsonSerializerDefaults.Web)
     };


### PR DESCRIPTION
<!-- Thank you for contributing to Repo-Template.
Please complete the following template to submit your pull request. -->

## Description

The Options property of a WebApiHelper is now public, meaning that it can be changed after the creation of the instance.

Fixes #2 

## Type of change

Please mark all options that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings